### PR TITLE
Remove unecessary data from api/matches return

### DIFF
--- a/repository/MatchRepo.js
+++ b/repository/MatchRepo.js
@@ -1,32 +1,43 @@
 import sequelize from '../db.js'
 
-const formatMatches = results => {
-  let obj = {
-    match_id: 0,
+const defineMatch = matchStat => {
+  const match = {
+    map: matchStat.map,
+    ct_score: matchStat.ct_score,
+    t_score: matchStat.t_score,
+    m_winner: matchStat.m_winner,
+    players: [],
   }
+  return match
+}
 
-  const matches = []
+const definePlayer = matchStat => {
+  let player = {
+    steamid: matchStat.steamid,
+    username: matchStat.username,
+    team: matchStat.team,
+    kills: matchStat.kills,
+    assists: matchStat.assists,
+    deaths: matchStat.deaths,
+    mvps: matchStat.mvps,
+    score: matchStat.score,
+  }
+  return player
+}
 
-  const hash = results.reduce(
-    (p, c) => (p[c.matchId] ? p[c.matchId].push(c) : (p[c.matchId] = [c]), p),
-    {}
-  )
+const formatMatches = results => {
+  let matches = []
+  let previous = 0
 
-  const newData = Object.keys(hash).map(k => ({matchId: k, pstats: hash[k]}))
-
-  newData.map(details => {
-    obj = {
-      id: details.matchId,
-      created: details.pstats[0].createdAt,
-      map_name: details.pstats[0].map,
-      ct_score: details.pstats[0].ct_score,
-      t_score: details.pstats[0].t_score,
-      winner: details.pstats[0].m_winner,
-      players_details: details.pstats,
+  results.map(matchStat => {
+    if (matchStat.matchId !== previous) {
+      matches.push(defineMatch(matchStat))
+      matches[matches.length - 1].players.push(definePlayer(matchStat))
+      previous = matchStat.matchId
+    } else {
+      matches[matches.length - 1].players.push(definePlayer(matchStat))
     }
-    matches.push(obj)
   })
-
   return matches
 }
 


### PR DESCRIPTION
Map name, t_score, ct_score, map winner and some other data were being return in each player of a match return. Now every match is an object with map name, t_score, ct_score, map winner and a players array carrying players informations like kills, assists and current team but no more map related informations.
