### PR TITLE
Fix path to repostory in controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # MixCSGO backend
 
-```
 After cloning the project.
 
 1 - Install all dependencies
+```
 npm i
+```
 
 2- Run project with Nodemon
+```
 npm run dev
+```
 
 Project routes are secured and require you to be authenticated. As I carry out my API tests using Postman and I don't know how to configure the jwt token to be received by it, what I currently do is login through the frontend of the application, get the authentication token in the browser cookies and register in Postman.
 
 You can also navigate using the frontend of the application itself. All API routes are defined in routes.js.
-```
 
 # DATABASE
 

--- a/controllers/EventControllers.js
+++ b/controllers/EventControllers.js
@@ -9,7 +9,7 @@ import {
   getEventsInDb,
   isUserCheckedIn,
   updateEventInDb,
-} from '../Repository/EventRepo.js'
+} from '../repository/EventRepo.js'
 
 export const createEvent = async (req, res) => {
   if (!req.body.description) {

--- a/controllers/MatchControllers.js
+++ b/controllers/MatchControllers.js
@@ -1,4 +1,4 @@
-import {getMatchesInDb} from '../Repository/MatchRepo.js'
+import {getMatchesInDb} from '../repository/MatchRepo.js'
 
 export const getAllMatches = (req, res) => {
   getMatchesInDb().then(matches => {

--- a/controllers/UserControllers.js
+++ b/controllers/UserControllers.js
@@ -1,4 +1,4 @@
-import {getUsersInDb} from '../Repository/UserRepo.js'
+import {getUsersInDb} from '../repository/UserRepo.js'
 
 export const getAllUsers = (req, res) => {
   getUsersInDb().then(users => {


### PR DESCRIPTION
**Problema**
Após instalar o projeto, nodemon quebra por que não consegue encontrar caminho para arquivos na pasta `repository`, especificados nos `controllers`.

**Solução**
Aparentemente, a pasta `Repository` foi modificada para `repository`. Esse PR atualiza essa rota nos arquivos
- `EventControllers`
- `MatchControllers` e 
- `UserControllers`

**Validação**
Após clonar o projeto e instalar as dependências, execute o script `dev` e verifique que o serviço executa sem erros.